### PR TITLE
  Filewatcher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docopt==0.6.2
 urwid==1.3.0
+watchdog==0.8.3

--- a/todotxt_machine/cli.py
+++ b/todotxt_machine/cli.py
@@ -151,7 +151,6 @@ def main():
 
     todos.autosave = enable_autosave
 
-    print(os.path.split(todotxt_file_path)[0])
     observer = Observer()
     observer.schedule(AutoLoad(patterns=['*/'+os.path.split(todotxt_file_path)[1]]), 
             os.path.split(todotxt_file_path)[0], recursive=False)

--- a/todotxt_machine/cli.py
+++ b/todotxt_machine/cli.py
@@ -30,6 +30,8 @@ from todotxt_machine.urwid_ui import UrwidUI
 from todotxt_machine.colorscheme import ColorScheme
 from todotxt_machine.keys import KeyBindings
 
+from watchdog.observers import Observer
+from watchdog.events import PatternMatchingEventHandler
 
 # Import the correct version of configparser
 if sys.version_info[0] >= 3:
@@ -41,7 +43,7 @@ elif sys.version_info[0] < 3:
 
 
 autosave_lock = threading.Lock()
-
+recent_autosave = False
 
 def autosave():
     if not enable_autosave:
@@ -51,17 +53,28 @@ def autosave():
     with autosave_lock:
         # view.save_todos() # TODO: Saved message isn't displayed, need to force redraw urwid ui?
         view.todos.save()
+        global recent_autosave
+        recent_autosave = True
 
     # Check the flag once again, as the flag may have been set
     # after the last check but before this statement is executed.
     if enable_autosave:
         global timer
-        timer = threading.Timer(30.0, autosave)
+        timer = threading.Timer(10.0, autosave)
         timer.start()
 
 
-timer = threading.Timer(30.0, autosave)
+timer = threading.Timer(10.0, autosave)
 
+class AutoLoad(PatternMatchingEventHandler):
+    def on_modified(self, event):
+        global recent_autosave
+        if recent_autosave:
+            recent_autosave = False
+            return
+
+        view.reload_todos_from_file()
+        view.loop.draw_screen()
 
 def exit_with_error(message):
     sys.stderr.write(message.strip(' \n') + '\n')
@@ -162,6 +175,12 @@ def main():
         exit_with_error("ERROR: unable to open {0}\n\nEither specify one as an argument on the command line or set it in your configuration file ({0}).".format(todotxt_file_path, arguments['--config']))
         todos = Todos([], todotxt_file_path, donetxt_file_path)
 
+    print(os.path.split(todotxt_file_path)[0])
+    observer = Observer()
+    observer.schedule(AutoLoad(patterns=['*/'+os.path.split(todotxt_file_path)[1]]), 
+            os.path.split(todotxt_file_path)[0], recursive=False)
+    observer.start()
+
     show_toolbar = get_boolean_config_option(cfg, 'settings', 'show-toolbar')
     show_filter_panel = get_boolean_config_option(cfg, 'settings', 'show-filter-panel')
     enable_borders = get_boolean_config_option(cfg, 'settings', 'enable-borders')
@@ -179,6 +198,9 @@ def main():
         show_filter_panel)
 
     # UI is now shut down
+
+    observer.stop()
+    observer.join()
 
     # Shut down the auto-saving thread.
     enable_autosave = False

--- a/todotxt_machine/todo.py
+++ b/todotxt_machine/todo.py
@@ -3,7 +3,6 @@
 import re
 import random
 from datetime import date
-import threading
 
 class Todo:
     """Single Todo item"""

--- a/todotxt_machine/todo.py
+++ b/todotxt_machine/todo.py
@@ -3,13 +3,13 @@
 import re
 import random
 from datetime import date
-
+import threading
 
 class Todo:
     """Single Todo item"""
     _priority_regex = re.compile(r'\(([A-Z])\) ')
 
-    def __init__(self, item, index,
+    def __init__(self, item, index, parent,
                  colored="", priority="", contexts=[], projects=[],
                  creation_date="", due_date="", completed_date=""):
         self.raw = item.strip()
@@ -21,6 +21,7 @@ class Todo:
         self.due_date = due_date
         self.completed_date = completed_date
         self.colored = self.highlight()
+        self.parent = parent
         # self.colored_length = TerminalOperations.length_ignoring_escapes(self.colored)
 
     def update(self, item):
@@ -32,6 +33,8 @@ class Todo:
         self.due_date = Todos.due_date(item)
         self.completed_date = Todos.completed_date(item)
         self.colored = self.highlight()
+        if self.parent.autosave:
+            self.parent.save()
         # self.colored_length = TerminalOperations.length_ignoring_escapes(self.colored)
 
     def __repr__(self):
@@ -142,11 +145,19 @@ class Todos:
     def __init__(self, todo_items, file_path, archive_path):
         self.file_path = file_path
         self.archive_path = archive_path
+        self.autosave = True
         self.update(todo_items)
 
     def reload_from_file(self):
+        current=[t.raw + '\n' for t in self.todo_items]
         with open(self.file_path, "r") as todotxt_file:
-            self.update(todotxt_file.readlines())
+            loaded=todotxt_file.readlines()
+
+        if loaded != current:
+            self.update(loaded)
+            return True
+        else:
+            return False
 
     def save(self):
         with open(self.file_path, "w") as todotxt_file:
@@ -168,6 +179,8 @@ class Todos:
 
     def update(self, todo_items):
         self.parse_raw_entries(todo_items)
+        if self.autosave:
+            self.save()
 
     def append(self, item, add_creation_date=True):
         self.insert(len(self.todo_items), item, add_creation_date)
@@ -179,11 +192,15 @@ class Todos:
         newtodo = self.todo_items[index]
         if add_creation_date and newtodo.creation_date == "":
             newtodo.add_creation_date()
+        if self.autosave:
+            self.save()
         return index
 
     def delete(self, index):
         del self.todo_items[index]
         self.update_raw_indices()
+        if self.autosave:
+            self.save()
 
     def __iter__(self):
         self.index = -1
@@ -223,7 +240,7 @@ class Todos:
         return repr([i for i in self.todo_items])
 
     def create_todo(self, todo, index):
-        return Todo(todo, index,
+        return Todo(todo, index, self,
                     contexts=Todos.contexts(todo),
                     projects=Todos.projects(todo),
                     priority=Todos.priority(todo),
@@ -321,6 +338,9 @@ class Todos:
             second = n_items - second
 
         self.todo_items[first], self.todo_items[second] = self.todo_items[second], self.todo_items[first]
+
+        if self.autosave:
+            self.save()
 
     def filter_context(self, context):
         return [item for item in self.todo_items if context in item.contexts]

--- a/todotxt_machine/urwid_ui.py
+++ b/todotxt_machine/urwid_ui.py
@@ -179,6 +179,9 @@ class TodoWidget(urwid.Button):
             self.parent_ui.update_filters(new_contexts=self.todo.contexts, new_projects=self.todo.projects)
         self.editing = False
 
+        if self.parent_ui.todos.autosave:
+            self.parent_ui.todos.save()
+
     def keypress(self, size, key):
         if self.editing:
             if key in ['down', 'up']:
@@ -453,14 +456,13 @@ class UrwidUI:
             self.update_header()
 
     def reload_todos_from_file(self, button=None):
-        self.delete_todo_widgets()
+        if self.todos.reload_from_file():
+            self.delete_todo_widgets()
+            
+            for t in self.todos.todo_items:
+                self.listbox.body.append(TodoWidget(t, self.key_bindings, self.colorscheme, self, wrapping=self.wrapping[0], border=self.border[0]))
 
-        self.todos.reload_from_file()
-
-        for t in self.todos.todo_items:
-            self.listbox.body.append(TodoWidget(t, self.key_bindings, self.colorscheme, self, wrapping=self.wrapping[0], border=self.border[0]))
-
-        self.update_header("Reloaded")
+            self.update_header("Reloaded")
 
     def keystroke(self, input):
         focus, focus_index = self.listbox.get_focus()


### PR DESCRIPTION
Replace timer-based autosave with save-on-change instead. Use watchdog to detect underlying file changes (e.g. from external sync program) to reload automatically.