### PR TITLE
Prepopulate new todos with current filters

### DIFF
--- a/todotxt_machine/urwid_ui.py
+++ b/todotxt_machine/urwid_ui.py
@@ -587,9 +587,12 @@ class UrwidUI:
 
         if self.filtering:
             position = 'append'
+            prepopulate = ' '.join(set(self.active_contexts)) + ' '.join(set(self.active_projects)) 
+        else:
+            prepoulate = ''
 
         if position is 'append':
-            new_index = self.todos.append('', add_creation_date=False)
+            new_index = self.todos.append(prepopulate, add_creation_date=False)
             self.listbox.body.append(TodoWidget(self.todos[new_index], self.key_bindings, self.colorscheme, self, editing=True, wrapping=self.wrapping[0], border=self.border[0]))
         else:
             if position is 'insert_after':


### PR DESCRIPTION
When adding new todo items while filtered, prepopulate new todo with same contexts and projects.